### PR TITLE
Add URL patterns for Beta Cluster and Toolforge

### DIFF
--- a/background.js
+++ b/background.js
@@ -51,6 +51,9 @@ var debug = {
         '*://*.wikiversity.org/*',
         '*://*.wikivoyage.org/*',
         '*://*.wiktionary.org/*',
+        '*://*.beta.wmflabs.org/*',
+        '*://*.tools.wmflabs.org/*',
+        '*://*.tools-static.wmflabs.org/*',
     ],
 
     // Current state: if true, inject header; if not, do nothing.


### PR DESCRIPTION
Add URL patterns for the webRequest.onBeforeSendHeaders binding that
will match hosts in Beta Cluster and Toolforge. Toolforge was supported
previously by the Firefox specific plugin.

Closes #12