### PR TITLE
Add switch for serving content via PHP 7.x

### DIFF
--- a/background.js
+++ b/background.js
@@ -30,6 +30,9 @@ var debug = {
         if ( debug.log ) {
             attributes.push( 'log' );
         }
+        if ( debug.php7 ) {
+            attributes.push( 'php7' );
+        }
 
         return {
             name  : 'X-Wikimedia-Debug',
@@ -71,6 +74,9 @@ var debug = {
     // Should MediaWiki process request in $wgReadOnly-mode?
     readonly: false,
 
+    // Should the content be served via php-fpm?
+    php7: false,
+
     // Toggle state.
     toggle: function ( state ) {
         debug.enabled = state;
@@ -79,6 +85,8 @@ var debug = {
             chrome.alarms.create( 'autoOff', { delayInMinutes: 15 } );
         }
     },
+
+
 
     // Dim the toolbar icon when inactive.
     updateIcon: function () {
@@ -108,6 +116,7 @@ var debug = {
             debug.log = request.log;
             debug.profile = request.profile;
             debug.readonly = request.readonly;
+            debug.php7 = request.php7;
         } else if ( request.action === 'get' ) {
             sendResponse( {
                 action   : 'state',
@@ -116,6 +125,7 @@ var debug = {
                 log      : debug.log,
                 profile  : debug.profile,
                 readonly : debug.readonly,
+                php7     : debug.php7
             } );
         }
     }

--- a/popup.html
+++ b/popup.html
@@ -18,7 +18,8 @@
       <div>
         <label><input class=option type=checkbox id=profile>Profile</label>
         <label><input class=option type=checkbox id=readonly>Read-only</label>
-        <label><input class=option type=checkbox id=log>Log</label>
+        <label><input class=option type=checkbox id=log>Log</label><br />
+        <label><input class=option type=checkbox id=php7>PHP 7.x</label>
       </div>
     </div>
     <div class=switch-container>


### PR DESCRIPTION
This gets translated to a cookie only sent to the backend servers on the
debug proxy, meaning we're not fiddling with user's cookies

Bug: T176370